### PR TITLE
Add render_template macro

### DIFF
--- a/src/amber/controller/helpers/render_module.cr
+++ b/src/amber/controller/helpers/render_module.cr
@@ -2,6 +2,14 @@ module Amber::Controller::Helpers
   module RenderModule
     LAYOUT = "application.slang"
 
+    private macro render_template(filename, path = "src/views")
+      {% if filename.id.split("/").size > 2 %}
+        Kilt.render("{{filename.id}}")
+      {% else %}
+        Kilt.render("#{{{path}}}/{{filename.id}}")
+       {% end %}
+    end
+
     # render the template or partial from the same folder as the calling artifact
     macro render_module(template = nil, layout = true, partial = nil, path = "src/views", folder = __DIR__)
       {% if !(template || partial) %}
@@ -29,6 +37,5 @@ module Amber::Controller::Helpers
         %content
       {% end %}
     end
-
   end
 end


### PR DESCRIPTION
`render_template` was modified by @elorest on https://github.com/amberframework/amber/pull/791, this PR add previous `render_template` to fix modular recipe

/cc @damianham 